### PR TITLE
fix: move scene ui fields to update cycle

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,13 @@
-import { Actor, Color, DisplayMode, Engine, vec, CollisionType, Vector, Scene, Label, Font, FontUnit, Text, ParticleEmitter, Timer } from "excalibur";
+import { Actor, Color, DisplayMode, Engine, vec, CollisionType, Vector, Scene, Label, Font, FontUnit, Text, ParticleEmitter, Timer, Input, Random } from "excalibur";
 import { DevTool } from "./dev-tools";
+
+const rand = new Random(1234)
+
+const fontOptions = {
+    family: 'Times New Roman',
+    size: 30, 
+    unit: FontUnit.Px
+};
 
 const game = new Engine({
     width: 800,
@@ -44,11 +52,7 @@ game.add(ground);
 
 const text = new Text({
     text: "Yo it's text",
-    font: new Font({
-        family: 'Times New Roman',
-        size: 30,
-        unit: FontUnit.Px
-    }),
+    font: new Font(fontOptions),
 });
 const label = new Actor({
     pos: vec(400, 100)
@@ -126,5 +130,46 @@ var emitter = new ParticleEmitter({
 otherScene.add(emitter);
 
 game.start();
+
+const dynamicSceneKey = 'dynamic scene';
+
+const createDynamicScene = () => {
+    if(dynamicSceneKey in game.scenes) {
+        game.removeScene(dynamicSceneKey);
+    }
+
+    const dynamicScene = new Scene();
+
+    for (let index = 0; index < rand.integer(1, 5); index++) {        
+        const label = new Actor({ 
+            pos: vec(10, 30 + (index * 30)),
+            anchor: vec(0, 0),
+        });
+        const text = new Text({
+            text: `Dynamically added scene with varying entities ${index} 👋`,
+            font: new Font({ ...fontOptions, size: 18 }),
+            color: Color.Orange,
+        });
+        label.graphics.use(text);
+        dynamicScene.add(label);
+    }
+    
+    game.addScene(dynamicSceneKey, dynamicScene);
+};
+
+game.input.keyboard.on("press", (evt: Input.KeyEvent) => {
+    switch(evt.key) {
+        // Add a dynamic scene, without activating it. This should still be reflected in dev tools
+        case Input.Keys.N:
+            createDynamicScene();
+            break;
+            
+        // Add a dynamic scene and activate it
+        case Input.Keys.A:
+            createDynamicScene();
+            game.goToScene(dynamicSceneKey);
+            break;
+    } 
+});
 
 const devtool = new DevTool(game);


### PR DESCRIPTION
Resolves bug discussed in https://github.com/excaliburjs/Excalibur/discussions/2399

Line 705 of dev-tools is slightly heavy, but it needs to account for both dynamic scenes added and dynamic scenes added _and_ activated. I've demonstrated this in the last example in `index.ts`. Even with a lot of scenes, I think this check would still be quick enough for development. 

In the examples, pressing "N" will add a scene, but not activate it, and pressing "A" will both add and activate a scene. In both cases we expect to see the scene list in the dev tools ui to update. 

**Additional information**
 - In the https://github.com/excaliburjs/Excalibur/blob/main/.github/CONTRIBUTING.md#commit-messages guide, it says for the commit message to start with a cap. It seems like this repo and the core repo follow more of a commitizen style of fix, feat, chore, etc, so I followed that here too
 - Edit: first PR around these parts, feel free to go hard, good to get alignment at the start :) 
  
Side question - I had a bit of trouble using `npm link` to test my unpublished version against a local project. To be fair, I didn't dig too deep, but is that something that works on your end? 